### PR TITLE
Add No Display

### DIFF
--- a/data/com.system76.CosmicNotifications.desktop
+++ b/data/com.system76.CosmicNotifications.desktop
@@ -8,4 +8,5 @@ Categories=GNOME;GTK;
 Keywords=Gnome;GTK;
 Icon=com.system76.CosmicNotifications
 StartupNotify=true
+NoDisplay=true
 X-HostWaylandDisplay=true


### PR DESCRIPTION
Found this while using KDE when trying to get to my code editor cosmic-notifications would always be first.