### PR TITLE
Fixes for systems without systemd-journald

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1"
 nix = "0.26.2"
 once_cell = "1.17"
 tracing-subscriber = "0.3.17"
-tracing-journald = "0.3.0"
+tracing-journald = { version = "0.3.0", optional = true }
 rust-embed = "8.4.0"
 serde = { version = "1.0.152", features = ["derive"] }
 ron = "0.8"
@@ -52,6 +52,10 @@ log-panics = { version = "2", features = ["with-backtrace"] }
 # [patch."https://github.com/pop-os/libcosmic"]
 # cosmic-config = { git = "https://github.com/pop-os/libcosmic//" }
 # libcosmic = { git = "https://github.com/pop-os/libcosmic//" }
+
+[features]
+systemd = ["dep:tracing-journald"]
+default = ["systemd"]
 
 [workspace]
 members = ["cosmic-notifications-util", "cosmic-notifications-config"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,10 @@ use localize::localize;
 use crate::config::VERSION;
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::registry()
-        .with(tracing_journald::layer()?)
+    let trace = tracing_subscriber::registry();
+    #[cfg(feature = "systemd")]
+    let trace = trace.with(tracing_journald::layer()?);
+    trace
         .with(fmt::layer())
         .with(
             EnvFilter::builder()


### PR DESCRIPTION
This PR is nearly identical in form to https://github.com/pop-os/cosmic-session/pull/59

It lowers `tracing_journald` to an optional dependency which is depended on by the `systemd` feature, and provides a fallback and a warning for when journald is not present at runtime.