### PR TITLE
fix: freeze in Firefox for a few seconds after receiving notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,6 +856,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-backtrace"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2123a5984bd52ca861c66f66a9ab9883b27115c607f801f86c1bc2a84eb69f0f"
+dependencies = [
+ "backtrace",
+ "termcolor",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1022,7 @@ name = "cosmic-notifications"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "color-backtrace",
  "cosmic-notifications-config",
  "cosmic-notifications-util",
  "cosmic-panel-config",
@@ -1019,7 +1030,6 @@ dependencies = [
  "i18n-embed",
  "i18n-embed-fl",
  "libcosmic",
- "log-panics",
  "ron 0.9.0",
  "rust-embed",
  "rustix 1.0.3",
@@ -2961,16 +2971,6 @@ name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
-
-[[package]]
-name = "log-panics"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
-dependencies = [
- "backtrace",
- "log",
-]
 
 [[package]]
 name = "lru"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,13 @@ i18n-embed = { version = "0.15.3", features = [
     "desktop-requester",
 ] }
 i18n-embed-fl = "0.9.3"
+color-backtrace = "0.7.0"
+cosmic-notifications-util = { path = "./cosmic-notifications-util" }
+cosmic-notifications-config = { path = "./cosmic-notifications-config" }
+cosmic-panel-config = { git = "https://github.com/pop-os/cosmic-panel" }
 cosmic-time = { git = "https://github.com/pop-os/cosmic-time", default-features = false, features = [
     "once_cell",
 ] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3.19", features = ["std", "env-filter"] }
-tracing-journald = { version = "0.3.1", optional = true }
 rust-embed = "8.6.0"
 rustix = "1.0.3"
 serde = { version = "1.0.219", features = ["derive"] }
@@ -39,11 +40,10 @@ tokio = { version = "1.44.1", features = [
     "net",
     "io-util",
 ] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3.19", features = ["std", "env-filter"] }
+tracing-journald = { version = "0.3.1", optional = true }
 zbus = { version = "4.4.0", features = ["tokio", "p2p"] }
-cosmic-notifications-util = { path = "./cosmic-notifications-util" }
-cosmic-notifications-config = { path = "./cosmic-notifications-config" }
-cosmic-panel-config = { git = "https://github.com/pop-os/cosmic-panel" }
-log-panics = { version = "2", features = ["with-backtrace"] }
 
 # remove after cosmic-panel is updated to use zbus v4
 # [patch."https://github.com/pop-os/libcosmic"]

--- a/build.rs
+++ b/build.rs
@@ -1,1 +1,1 @@
-pub fn main() {}
+fn main() {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use localize::localize;
 use crate::config::VERSION;
 
 fn main() -> anyhow::Result<()> {
+    color_backtrace::install();
     let trace = tracing_subscriber::registry();
 
     let env_filter = EnvFilter::builder()
@@ -31,8 +32,6 @@ fn main() -> anyhow::Result<()> {
 
     #[cfg(not(feature = "systemd"))]
     trace.with(fmt::layer()).with(env_filter).try_init()?;
-
-    log_panics::init();
 
     info!("cosmic-notifications ({})", APP_ID);
     info!("Version: {} ({})", VERSION, config::profile());


### PR DESCRIPTION
This fixed an issue causing Firefox to stall for the duration that a new notification was displayed upon receiving it. I've refactored the notification subscription and application to eliminate mutexes and locks.