### PR TITLE
Support file:// URLs in app_icon field

### DIFF
--- a/cosmic-notifications-util/src/lib.rs
+++ b/cosmic-notifications-util/src/lib.rs
@@ -149,7 +149,20 @@ impl Notification {
                 data,
             }) => Some(icon::from_raster_pixels(*width, *height, data.clone()).icon()),
             None => {
-                (!self.app_icon.is_empty()).then(|| icon::from_name(self.app_icon.as_str()).icon())
+                if !self.app_icon.is_empty() {
+                    // Handle file:// URLs in app_icon
+                    if self.app_icon.starts_with("file://") {
+                        if let Ok(url) = url::Url::parse(&self.app_icon) {
+                            if let Ok(path) = url.to_file_path() {
+                                return Some(icon::from_path(path).icon());
+                            }
+                        }
+                    }
+                    // Otherwise treat as icon name
+                    Some(icon::from_name(self.app_icon.as_str()).icon())
+                } else {
+                    None
+                }
             }
         }
     }


### PR DESCRIPTION
Handle file:// URLs in the app_icon field for notifications from Chromium-based browsers (e.g., Helium, Chrome, Chromium).

These browsers send temporary icon file paths like:
  file:///tmp/org.chromium.Chromium.scoped_dir.XXX/logo.png

Previously, COSMIC tried to load these as icon names via from_name(), which failed. Now we:
- Detect file:// URL prefix in app_icon
- Parse and convert to file path
- Load icon using from_path() instead

This allows app icons to display correctly in notifications from web applications running in Chromium-based browsers.

---

This was originally posted as part of #130, which was closed in favor of #115. However, only part of #130 was related to the HTML stripping feature.