### PR TITLE
feat(markup): Improve HTML stripping and add tests

### DIFF
--- a/cosmic-notifications-util/src/markup.rs
+++ b/cosmic-notifications-util/src/markup.rs
@@ -11,12 +11,44 @@ use cosmic::{
 // Used only in `parse_html` function
 fn _prepare_html(text: &str) -> String {
     let text = text
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
         // handle break lines
         .replace("<br>", "\n")
         .replace("<br/>", "\n")
         .replace("<br />", "\n");
 
     text.to_owned()
+}
+
+fn collect_text(handle: &tl::NodeHandle, parser: &tl::Parser, buffer: &mut String) {
+    if let Some(node) = handle.get(parser) {
+        match node {
+            tl::Node::Tag(tag) => {
+                tag.children().top().iter().for_each(|t| {
+                    collect_text(t, parser, buffer);
+                });
+            }
+            tl::Node::Raw(bytes) => {
+                buffer.push_str(&bytes.as_utf8_str());
+            }
+            _ => {}
+        }
+    }
+}
+
+pub fn strip_html(text: &str) -> String {
+    if let Ok(dom) = tl::parse(text, tl::ParserOptions::default()) {
+        let parser = dom.parser();
+        let mut buffer = String::new();
+        for node_handle in dom.children() {
+            collect_text(node_handle, parser, &mut buffer);
+        }
+        buffer
+    } else {
+        text.to_string()
+    }
 }
 
 // Sanitize only tags allowed by Freedesktop Notification Specifications
@@ -81,7 +113,97 @@ pub fn html_to_spans(text: &str) -> Vec<Span<'static>> {
         for node_handle in elements {
             _handle_recursive(node_handle, parser, &mut tags, &mut buffer);
         }
+    } else {
+        buffer.push(Span::new(strip_html(text)));
     }
 
     buffer
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_html() {
+        assert_eq!(strip_html("<b>hello</b>"), "hello");
+        assert_eq!(strip_html("<i>hello</i>"), "hello");
+        assert_eq!(strip_html("<u>hello</u>"), "hello");
+        assert_eq!(strip_html("<a>hello</a>"), "hello");
+        assert_eq!(strip_html("<p>hello</p>"), "hello");
+        assert_eq!(strip_html("<b><i><u><a>hello</a></u></i></b>"), "hello");
+        assert_eq!(strip_html("hello"), "hello");
+        assert_eq!(strip_html(""), "");
+        assert_eq!(strip_html("<b>invalid"), "invalid");
+    }
+
+    #[test]
+    fn test_html_to_spans_simple() {
+        let spans = html_to_spans("hello");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].text, "hello");
+        assert_eq!(spans[0].font.unwrap().weight, Weight::Normal);
+        assert_eq!(spans[0].font.unwrap().style, Style::Normal);
+    }
+
+    #[test]
+    fn test_html_to_spans_bold() {
+        let spans = html_to_spans("<b>hello</b>");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].text, "hello");
+        assert_eq!(spans[0].font.unwrap().weight, Weight::Bold);
+    }
+
+    #[test]
+    fn test_html_to_spans_italic() {
+        let spans = html_to_spans("<i>hello</i>");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].text, "hello");
+        assert_eq!(spans[0].font.unwrap().style, Style::Italic);
+    }
+
+    #[test]
+    fn test_html_to_spans_underline() {
+        let spans = html_to_spans("<u>hello</u>");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].text, "hello");
+        assert!(spans[0].underline);
+    }
+
+    #[test]
+    fn test_html_to_spans_escaped() {
+        let spans = html_to_spans("&lt;b&gt;hello&lt;/b&gt;");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].text, "hello");
+        assert_eq!(spans[0].font.unwrap().weight, Weight::Bold);
+    }
+
+    #[test]
+    fn test_html_to_spans_mixed() {
+        let spans = html_to_spans("hello <b>world</b>");
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[0].text, "hello ");
+        assert_eq!(spans[0].font.unwrap().weight, Weight::Normal);
+        assert_eq!(spans[1].text, "world");
+        assert_eq!(spans[1].font.unwrap().weight, Weight::Bold);
+    }
+
+    #[test]
+    fn test_html_to_spans_br() {
+        let spans = html_to_spans("hello<br>world");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].text, "hello\nworld");
+    }
+
+    #[test]
+    fn test_html_to_spans_unclosed_tag() {
+        let spans = html_to_spans("<b hello");
+        assert!(spans.is_empty());
+    }
+
+    #[test]
+    fn test_html_to_spans_malformed_tag() {
+        let spans = html_to_spans("<");
+        assert!(spans.is_empty());
+    }
 }


### PR DESCRIPTION
 improvements to the HTML markup processing for notifications:

- Adds unescaping for basic HTML entities (`&lt;`, `&gt;`, `&amp;`) to correctly parse escaped tags.
- Implements a robust `strip_html` function to remove all HTML tags from a string.

- [ ] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

