### PR TITLE
Option to persist notifications

### DIFF
--- a/cosmic-notifications-config/src/lib.rs
+++ b/cosmic-notifications-config/src/lib.rs
@@ -33,6 +33,8 @@ pub struct NotificationsConfig {
     pub max_timeout_normal: Option<u32>,
     /// Max time in milliseconds a low priority notification can be displayed before being removed.
     pub max_timeout_low: Option<u32>,
+    /// Notifications persist until dismissed.
+    pub persistence: bool,
 }
 
 impl Default for NotificationsConfig {
@@ -45,6 +47,7 @@ impl Default for NotificationsConfig {
             max_timeout_urgent: None,
             max_timeout_normal: Some(5000),
             max_timeout_low: Some(3000),
+            persistence: false,
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -243,17 +243,20 @@ impl CosmicNotifications {
         &mut self,
         notification: Notification,
     ) -> Task<<CosmicNotifications as cosmic::app::Application>::Message> {
-        let mut timeout = u32::try_from(notification.expire_timeout).unwrap_or(3000);
-        let max_timeout = if notification.urgency() == 2 {
-            self.config.max_timeout_urgent
-        } else if notification.urgency() == 1 {
-            self.config.max_timeout_normal
+        let timeout = if !self.config.persistence {
+            let timeout = u32::try_from(notification.expire_timeout).unwrap_or(3000);
+            let max_timeout = if notification.urgency() == 2 {
+                self.config.max_timeout_urgent
+            } else if notification.urgency() == 1 {
+                self.config.max_timeout_normal
+            } else {
+                self.config.max_timeout_low
+            }
+            .unwrap_or(u32::try_from(notification.expire_timeout).unwrap_or(3000));
+            timeout.min(max_timeout)
         } else {
-            self.config.max_timeout_low
-        }
-        .unwrap_or(u32::try_from(notification.expire_timeout).unwrap_or(3000));
-        timeout = timeout.min(max_timeout);
-
+            0
+        };
         let mut tasks = vec![if timeout > 0 {
             iced::Task::perform(
                 tokio::time::sleep(Duration::from_millis(timeout as u64)),


### PR DESCRIPTION
macOS supports persisting notifications until dismissed. This is useful to keep important notifications around instead of having them time out. Currently, this applies to all apps but it composes well with per-app notification settings (which is a future feature, most likely).

See: pop-os/cosmic-settings#1878

---

This feature was requested in the linked PR. I'll likely implement per-app settings then move this setting over to that to match macOS. However, this works as intended for now. The easiest way to test it is to use `send-notify`.

To enable persistence, write `true` to the `persistence` settings file.

```sh
echo true > ~/.config/cosmic/com.system76.CosmicNotifications/v1/persistence
```

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

